### PR TITLE
Automatically install usb.ids and USB IDs update

### DIFF
--- a/Gallimaufry/usb.ids
+++ b/Gallimaufry/usb.ids
@@ -9,8 +9,8 @@
 #	The latest version can be obtained from
 #		http://www.linux-usb.org/usb.ids
 #
-# Version: 2018.07.03
-# Date:    2018-07-03 20:34:06
+# Version: 2018.08.09
+# Date:    2018-08-09 20:34:05
 #
 
 # Vendors, devices and interfaces. Please keep sorted.
@@ -18388,6 +18388,7 @@
 1fc9  NXP Semiconductors
 	0003  LPC1343
 	010b  PR533
+	012b  i.MX 8M Dual/8M QuadLite/8M Quad Serial Downloader
 1fde  ILX Lightwave Corporation
 	0001  UART Bridge
 1fe7  Vertex Wireless Co., Ltd.
@@ -19039,6 +19040,8 @@
 2dcf  Dialog Semiconductor
 	c952  Audio Class 2.0 Devices
 2fb2  Fujitsu, Ltd
+3016  Boundary Devices, LLC
+	0001  Nitrogen Bootloader
 3125  Eagletron
 	0001  TrackerPod Camera Stand
 3136  Navini Networks

--- a/setup.py
+++ b/setup.py
@@ -35,5 +35,6 @@ setup(
     install_requires=["enforce"],
     keywords='usb pcap parse',
     packages=find_packages(exclude=['contrib', 'docs', 'tests','lib','examples']),
+    data_files=[('Gallimaufry', ['Gallimaufry/usb.ids'])],
 )
 


### PR DESCRIPTION
With this modification, the file usb.ids is copied to the dist-packages folder during installation.