### PR TITLE
Remove enforce dependency

### DIFF
--- a/Gallimaufry/Classes/DualShock4.py
+++ b/Gallimaufry/Classes/DualShock4.py
@@ -6,7 +6,6 @@ import matplotlib.pyplot as plt
 
 # Based on: https://www.psdevwiki.com/ps4/DS4-USB
 
-#@enforce.runtime_validation
 class DualShock4:
 
     def __init__(self, pcap):

--- a/Gallimaufry/Classes/HID/Keyboard.py
+++ b/Gallimaufry/Classes/HID/Keyboard.py
@@ -1,10 +1,7 @@
 import logging
 logger = logging.getLogger("USB.Classes.HID.Keyboard")
 
-import enforce
 
-#@enforce.runtime_validation
-# Static method issue: https://github.com/RussBaz/enforce/issues/55
 class Keyboard:
 
     def __init__(self, pcap):

--- a/Gallimaufry/Classes/HID/Mouse.py
+++ b/Gallimaufry/Classes/HID/Mouse.py
@@ -1,9 +1,7 @@
 import logging
 logger = logging.getLogger("USB.Classes.HID.Mouse")
 
-import enforce
 
-#@enforce.runtime_validation
 class Mouse:
 
     def __init__(self, pcap):

--- a/Gallimaufry/Classes/HID/__init__.py
+++ b/Gallimaufry/Classes/HID/__init__.py
@@ -1,7 +1,6 @@
 import logging
 logger = logging.getLogger("USB.Classes.HID")
 
-import enforce
 
 SC_NONE = 0
 SC_BOOT = 1
@@ -21,7 +20,6 @@ protocol_str = {
         PROTO_MOUSE    : 'Mouse',
     }
 
-@enforce.runtime_validation
 class HID:
 
     def __init__(self, interface):

--- a/Gallimaufry/Classes/__init__.py
+++ b/Gallimaufry/Classes/__init__.py
@@ -2,9 +2,7 @@ import logging
 
 logger = logging.getLogger("USB.Classes")
 
-import enforce
 
-@enforce.runtime_validation
 def get_class_handler(class_id: int):
     """Returns the handler for the given class id."""
 

--- a/Gallimaufry/Configuration.py
+++ b/Gallimaufry/Configuration.py
@@ -1,4 +1,3 @@
-import enforce
 import logging
 
 logger = logging.getLogger("USB.Configuration")
@@ -6,7 +5,6 @@ logger = logging.getLogger("USB.Configuration")
 import typing
 from collections import OrderedDict
 
-@enforce.runtime_validation
 class Configuration:
     """Represents a USB Configuration.
 

--- a/Gallimaufry/Device.py
+++ b/Gallimaufry/Device.py
@@ -1,9 +1,7 @@
 import logging
 logger = logging.getLogger("USB.Device")
 
-import enforce
 
-@enforce.runtime_validation
 class Device:
     """Defines a USB device.
     

--- a/Gallimaufry/Endpoint.py
+++ b/Gallimaufry/Endpoint.py
@@ -1,4 +1,3 @@
-import enforce
 import logging
 
 logger = logging.getLogger("USB.Endpoint")
@@ -11,7 +10,6 @@ TT_ISOCHRONOUS = 1
 TT_BULK        = 2
 TT_INTERRUPT   = 3
 
-@enforce.runtime_validation
 class Endpoint:
     """Describes a USB Endpoint.
 

--- a/Gallimaufry/HID.py
+++ b/Gallimaufry/HID.py
@@ -1,6 +1,4 @@
-import enforce
 
-@enforce.runtime_validation
 class HID:
     """Describes a USB HID.
 

--- a/Gallimaufry/Interface.py
+++ b/Gallimaufry/Interface.py
@@ -1,11 +1,9 @@
-import enforce
 import typing
 from .HID import HID
 from .UVC import StreamingDescriptor, ControlDescriptor
 from .Endpoint import Endpoint
 from .Classes import get_class_handler
 
-@enforce.runtime_validation
 class Interface:
     """Describes a USB Interface.
 

--- a/Gallimaufry/USB.py
+++ b/Gallimaufry/USB.py
@@ -2,7 +2,6 @@ import logging
 logger = logging.getLogger("Gallimaufry.USB")
 
 from . import Colorer, settings
-import enforce
 import typing
 from collections import OrderedDict
 from .Device import Device
@@ -12,7 +11,6 @@ Packets = typing.List[typing.Dict]
 PacketsOut = typing.List[OrderedDict]
 TypeIntOptional = typing.Optional[int]
 
-@enforce.runtime_validation
 class USB:
     """Base class for defining a USB packet capture.
 

--- a/Gallimaufry/UVC.py
+++ b/Gallimaufry/UVC.py
@@ -1,4 +1,3 @@
-import enforce
 
 # Implementation of USB video class according to the document:
 # "Universal Serial Bus Device Class Definition for Video Devices"
@@ -64,7 +63,6 @@ streamingSubtypes = {
         VS_FORMAT_H264_SIMULCAST: 'Format H264 simulcast'
         }
 
-@enforce.runtime_validation
 class StreamingDescriptor:
     """Describes a Streaming descriptor.
 
@@ -95,7 +93,6 @@ class StreamingDescriptor:
         """str: String representation of descriptor subtype."""
         return streamingSubtypes[self.bDescriptorSubType]
 
-@enforce.runtime_validation
 class ControlDescriptor:
     """Describes a control descriptor.
 

--- a/Gallimaufry/helpers.py
+++ b/Gallimaufry/helpers.py
@@ -1,4 +1,3 @@
-import enforce
 import os
 import re
 
@@ -30,7 +29,6 @@ def read_usb_ids():
         ids = f.read().decode('cp1252')
     return ids
 
-@enforce.runtime_validation
 def resolve_vendor_id(vendor_id: int) -> str:
     ids = read_usb_ids()
 
@@ -45,7 +43,6 @@ def resolve_vendor_id(vendor_id: int) -> str:
 
     return vendors[0]
 
-@enforce.runtime_validation
 def resolve_product_id(vendor_id: int, product_id: int) -> str:
     ids = read_usb_ids()
     
@@ -69,19 +66,15 @@ def resolve_product_id(vendor_id: int, product_id: int) -> str:
 # Does it have the field?
 # 
 
-@enforce.runtime_validation
 def has_device_descriptor(packet) -> bool:
     return any(True for layer in packet['_source']['layers'].values() if 'usb.bDescriptorType' in layer and int(layer['usb.bDescriptorType'],16) == 1 and 'usb.bmRequestType' not in layer)
 
-@enforce.runtime_validation
 def has_configuration_descriptor(packet) -> bool:
     return any(True for layer in packet['_source']['layers'].values() if 'usb.bDescriptorType' in layer and int(layer['usb.bDescriptorType'],16) == 2)
 
-@enforce.runtime_validation
 def has_string_descriptor(packet) -> bool:
     return any(True for layer in packet['_source']['layers'].values() if 'usb.bDescriptorType' in layer and int(layer['usb.bDescriptorType'],16) == 3 and 'usb.bString' in layer)
 
-@enforce.runtime_validation
 def has_endpoint_descriptor(packet) -> bool:
     return any(True for layer in packet['_source']['layers'].values() if 'usb.bDescriptorType' in layer and int(layer['usb.bDescriptorType'],16) == 4)
 
@@ -89,6 +82,5 @@ def has_endpoint_descriptor(packet) -> bool:
 # Get the fields (assumes we know they exist)
 #
 
-@enforce.runtime_validation
 def get_configuration_descriptor(packet):
     return next(layer for layer in packet['_source']['layers'].values() if 'usb.bDescriptorType' in layer and int(layer['usb.bDescriptorType'],16) == 2)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-enforce==0.3.4
 sphinxcontrib-napoleon==0.6.1

--- a/setup.py
+++ b/setup.py
@@ -32,9 +32,8 @@ setup(
     extras_require={
         'dev': ['six','ipython','twine','pytest','python-coveralls','coverage','pytest-cov','pytest-xdist','sphinxcontrib-napoleon', 'sphinx_rtd_theme','sphinx-autodoc-typehints'],
     },
-    install_requires=["enforce", "matplotlib"],
+    install_requires=["matplotlib"],
     keywords='usb pcap parse',
     packages=find_packages(exclude=['contrib', 'docs', 'tests','lib','examples']),
     data_files=[('Gallimaufry', ['Gallimaufry/usb.ids'])],
 )
-


### PR DESCRIPTION
`enforce` hasn't worked on newer versions of Python in years. As noted in https://github.com/bannsec/gallimaufry/issues/8#issuecomment-492714472, we should remove it. I haven't done any testing with this, other than `from Gallimaufry.USB import USB` now works.